### PR TITLE
Device definitions available as patch releases (#19)

### DIFF
--- a/.github/workflows/pci-update-workflow.yml
+++ b/.github/workflows/pci-update-workflow.yml
@@ -104,7 +104,7 @@ jobs:
           # Get current version and increment minor version
           current_version = config['project']['version']
           major, minor, patch = current_version.split('.')
-          new_version = f"{major}.{int(minor) + 1}.0"
+          new_version = f"{major}.{minor}.{int(patch) + 1}"
           
           # Update version in config
           config['project']['version'] = new_version

--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ Supports Windows, Linux, and Mac.
 
 Add the following definition to your `requirements.txt` or `pyproject.toml` file:
 
-`torchruntime~=[version]`
+`torchruntime~=[major-ver].[minor-ver]`
 
-Replace `[version]` with the desired version of Torchruntime. Using the [compatible release operator](https://packaging.python.org/en/latest/specifications/version-specifiers/#compatible-release) allows for updated device definitions to be made available to users without further changes. You will still need to manually change the version specification when breaking changes are introduced.
+Replace `[major-ver]` and `[minor-ver]` with the desired Torchruntime release series, for example:
+
+`torchruntime~=1.20`
+
+Using the [compatible release operator](https://packaging.python.org/en/latest/specifications/version-specifiers/#compatible-release) allows updated device definitions and non-breaking changes to be made available to users without manual intervention. You will still need to update the definition when breaking changes are introduced in new major versions.
 
 ### Manually
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ It deals with the complexity of the variety of torch builds and configurations r
 # Installation
 Supports Windows, Linux, and Mac.
 
+### As a dependency
+
+Add the following definition to your `requirements.txt` or `pyproject.toml` file:
+
+`torchruntime~=[version]`
+
+Replace `[version]` with the desired version of Torchruntime. Using the [compatible release operator](https://packaging.python.org/en/latest/specifications/version-specifiers/#compatible-release) allows for updated device definitions to be made available to users without further changes. You will still need to manually change the version specification when breaking changes are introduced.
+
+### Manually
+
 `pip install torchruntime`
 
 ## Usage


### PR DESCRIPTION
- Switches automatic version bump from minor to patch
- Updated Readme file with compatible release operator sample

Resolves: #19 