### PR TITLE
Segmentation: add preview/unsupported build selection controls

### DIFF
--- a/API.md
+++ b/API.md
@@ -15,7 +15,7 @@ torchruntime.install(["torch", "torchvision<0.20"])
 
 Optional flags:
 - `preview=True` to allow preview builds (e.g. ROCm 6.4, nightly builds, XPU test index)
-- `unsupported=False` to forbid EOL/unsupported builds (errors instead of installing older builds)
+- `unsupported=False` to forbid EOL/unsupported builds (e.g. Torch-DirectML, IPEX, Torch 1.x)
 
 On Windows CUDA, Linux ROCm (6.x+), and Linux XPU, this also installs the appropriate Triton package to enable `torch.compile` (`triton-windows`, `pytorch-triton-rocm`, or `pytorch-triton-xpu`).
 

--- a/API.md
+++ b/API.md
@@ -13,6 +13,10 @@ Or you can use the library:
 torchruntime.install(["torch", "torchvision<0.20"])
 ```
 
+Optional flags:
+- `preview=True` to allow preview builds (e.g. ROCm 6.4, nightly builds, XPU test index)
+- `unsupported=False` to forbid EOL/unsupported builds (errors instead of installing older builds)
+
 On Windows CUDA, Linux ROCm (6.x+), and Linux XPU, this also installs the appropriate Triton package to enable `torch.compile` (`triton-windows`, `pytorch-triton-rocm`, or `pytorch-triton-xpu`).
 
 ## Test torch

--- a/API.md
+++ b/API.md
@@ -8,6 +8,8 @@ import torchruntime
 You can use the command line:
 `python -m torchruntime install <optional list of package names and versions>`
 
+CLI flags: `--policy <compat|stable|preview>`, `--preview`, `--no-unsupported`, `--uv`
+
 Or you can use the library:
 ```py
 torchruntime.install(["torch", "torchvision<0.20"])

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ On Windows CUDA, Linux ROCm (6.x+), and Linux XPU, this also installs the approp
 
 **Tip:** You can also add the `--uv` flag to install packages using [uv](https://docs.astral.sh/uv/) (instead of `pip`). For e.g. `python -m torchruntime install --uv`
 
+Build-selection options:
+- `--policy <name>`: `compat` (default), `stable`, `preview` (or `nightly`)
+- Overrides: `--preview`, `--no-unsupported`
+
 ### Step 2. Configure torch
 This should be run inside your program, to initialize the required environment variables (if any) for the variant of torch being used.
 

--- a/tests/test_platform_detection.py
+++ b/tests/test_platform_detection.py
@@ -36,7 +36,8 @@ def test_amd_gpu_navi4_linux(monkeypatch):
         with pytest.raises(NotImplementedError):
             get_torch_platform(gpu_infos)
     else:
-        assert get_torch_platform(gpu_infos) == "rocm6.2"
+        assert get_torch_platform(gpu_infos) == "cpu"
+        assert get_torch_platform(gpu_infos, preview=True) == "rocm6.4"
 
 
 def test_amd_gpu_navi3_linux(monkeypatch, capsys):

--- a/tests/test_platform_detection.py
+++ b/tests/test_platform_detection.py
@@ -36,7 +36,7 @@ def test_amd_gpu_navi4_linux(monkeypatch):
         with pytest.raises(NotImplementedError):
             get_torch_platform(gpu_infos)
     else:
-        assert get_torch_platform(gpu_infos) == "rocm6.4"
+        assert get_torch_platform(gpu_infos) == "rocm6.2"
 
 
 def test_amd_gpu_navi3_linux(monkeypatch, capsys):
@@ -87,6 +87,14 @@ def test_amd_gpu_ellesmere_linux(monkeypatch):
     monkeypatch.setattr("torchruntime.platform_detection.arch", "x86_64")
     gpu_infos = [GPU(AMD, "AMD", 0x1234, "Ellesmere", True)]
     assert get_torch_platform(gpu_infos) == "rocm4.2"
+
+
+def test_amd_gpu_ellesmere_linux_unsupported_false_raises(monkeypatch):
+    monkeypatch.setattr("torchruntime.platform_detection.os_name", "Linux")
+    monkeypatch.setattr("torchruntime.platform_detection.arch", "x86_64")
+    gpu_infos = [GPU(AMD, "AMD", 0x1234, "Ellesmere", True)]
+    with pytest.raises(ValueError, match="End-of-Life"):
+        get_torch_platform(gpu_infos, unsupported=False)
 
 
 def test_amd_gpu_unsupported_linux(monkeypatch, capsys):

--- a/tests/test_policy_parsing.py
+++ b/tests/test_policy_parsing.py
@@ -1,0 +1,81 @@
+import pytest
+from torchruntime.utils.args import parse_policy_args
+
+
+def test_default_policy():
+    args = ["pkg1"]
+    preview, unsupported, cleaned = parse_policy_args(args)
+    assert preview is False
+    assert unsupported is True
+    assert cleaned == ["pkg1"]
+
+
+def test_stable_policy():
+    args = ["--policy", "stable", "pkg1"]
+    preview, unsupported, cleaned = parse_policy_args(args)
+    assert preview is False
+    assert unsupported is False
+    assert cleaned == ["pkg1"]
+
+
+def test_nightly_policy():
+    args = ["--policy", "nightly"]
+    preview, unsupported, cleaned = parse_policy_args(args)
+    assert preview is True
+    assert unsupported is True
+    assert cleaned == []
+
+
+def test_preview_policy_alias():
+    args = ["--policy", "preview"]
+    preview, unsupported, cleaned = parse_policy_args(args)
+    assert preview is True
+    assert unsupported is True
+    assert cleaned == []
+
+
+def test_policy_equals_syntax():
+    args = ["--policy=stable", "pkg1"]
+    preview, unsupported, cleaned = parse_policy_args(args)
+    assert preview is False
+    assert unsupported is False
+    assert cleaned == ["pkg1"]
+
+
+def test_policy_override_preview():
+    # stable is p=F, u=F. --preview should make p=T
+    args = ["--policy", "stable", "--preview"]
+    preview, unsupported, cleaned = parse_policy_args(args)
+    assert preview is True
+    assert unsupported is False
+
+def test_policy_override_unsupported():
+    # nightly is p=T, u=T. --no-unsupported should make u=F
+    args = ["--policy", "nightly", "--no-unsupported"]
+    preview, unsupported, cleaned = parse_policy_args(args)
+    assert preview is True
+    assert unsupported is False
+
+
+def test_unknown_policy():
+    args = ["--policy", "nonexistent"]
+    with pytest.raises(ValueError, match="Unknown policy"):
+        parse_policy_args(args)
+
+
+def test_missing_policy_arg():
+    args = ["--policy"]
+    with pytest.raises(ValueError, match="--policy requires an argument"):
+        parse_policy_args(args)
+
+
+def test_mixed_args():
+    args = ["torch", "--preview", "--policy", "stable", "--uv"]
+    # stable: p=F, u=F
+    # --preview: p=T
+    # Result: p=T, u=F
+    # cleaned: ["torch", "--uv"]
+    preview, unsupported, cleaned = parse_policy_args(args)
+    assert preview is True
+    assert unsupported is False
+    assert cleaned == ["torch", "--uv"]

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,0 +1,72 @@
+import pytest
+from torchruntime.device_db import GPU
+from torchruntime.platform_detection import AMD, INTEL, NVIDIA, get_torch_platform, py_version
+
+
+def test_preview_rocm_6_4_selection(monkeypatch):
+    monkeypatch.setattr("torchruntime.platform_detection.os_name", "Linux")
+    monkeypatch.setattr("torchruntime.platform_detection.arch", "x86_64")
+    gpu_infos = [GPU(AMD, "AMD", 0x1234, "Navi 41", True)]
+
+    if py_version < (3, 9):
+        pytest.skip("Navi 4 requires Python 3.9+")
+
+    # Default: preview=False -> rocm6.2
+    assert get_torch_platform(gpu_infos) == "rocm6.2"
+    assert get_torch_platform(gpu_infos, preview=False) == "rocm6.2"
+
+    # preview=True -> rocm6.4
+    assert get_torch_platform(gpu_infos, preview=True) == "rocm6.4"
+
+
+def test_eol_cu118_selection(monkeypatch):
+    monkeypatch.setattr("torchruntime.platform_detection.os_name", "Windows")
+    monkeypatch.setattr("torchruntime.platform_detection.arch", "amd64")
+    # Kepler architecture (e.g. GTX 780)
+    gpu_infos = [GPU(NVIDIA, "NVIDIA", "1004", "GK110 [GeForce GTX 780]", True)]
+
+    # Default: unsupported=True -> cu118
+    assert get_torch_platform(gpu_infos) == "cu118"
+    assert get_torch_platform(gpu_infos, unsupported=True) == "cu118"
+
+    # unsupported=False -> raises ValueError
+    with pytest.raises(ValueError, match="considered End-of-Life"):
+        get_torch_platform(gpu_infos, unsupported=False)
+
+
+def test_eol_rocm42_selection(monkeypatch):
+    monkeypatch.setattr("torchruntime.platform_detection.os_name", "Linux")
+    monkeypatch.setattr("torchruntime.platform_detection.arch", "x86_64")
+    # Ellesmere (e.g. RX 580)
+    gpu_infos = [GPU(AMD, "AMD", "67df", "Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]", True)]
+
+    # Default: unsupported=True -> rocm4.2
+    assert get_torch_platform(gpu_infos) == "rocm4.2"
+
+    # unsupported=False -> raises ValueError
+    with pytest.raises(ValueError, match="considered End-of-Life"):
+        get_torch_platform(gpu_infos, unsupported=False)
+
+
+def test_eol_directml_selection(monkeypatch):
+    monkeypatch.setattr("torchruntime.platform_detection.os_name", "Windows")
+    monkeypatch.setattr("torchruntime.platform_detection.arch", "amd64")
+    gpu_infos = [GPU(AMD, "AMD", 0x1234, "Radeon", True)]
+
+    assert get_torch_platform(gpu_infos) == "directml"
+
+    with pytest.raises(ValueError, match="considered End-of-Life"):
+        get_torch_platform(gpu_infos, unsupported=False)
+
+
+def test_eol_ipex_selection(monkeypatch):
+    monkeypatch.setattr("torchruntime.platform_detection.os_name", "Linux")
+    monkeypatch.setattr("torchruntime.platform_detection.arch", "x86_64")
+    monkeypatch.setattr("torchruntime.platform_detection.py_version", (3, 8))
+    gpu_infos = [GPU(INTEL, "Intel", 0x1234, "Iris", True)]
+
+    assert get_torch_platform(gpu_infos) == "ipex"
+
+    # unsupported=False -> raises ValueError
+    with pytest.raises(ValueError, match="considered End-of-Life"):
+        get_torch_platform(gpu_infos, unsupported=False)

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,6 +1,6 @@
 import pytest
 from torchruntime.device_db import GPU
-from torchruntime.platform_detection import AMD, INTEL, NVIDIA, get_torch_platform, py_version
+from torchruntime.platform_detection import AMD, INTEL, get_torch_platform, py_version
 
 
 def test_preview_rocm_6_4_selection(monkeypatch):
@@ -11,25 +11,21 @@ def test_preview_rocm_6_4_selection(monkeypatch):
     if py_version < (3, 9):
         pytest.skip("Navi 4 requires Python 3.9+")
 
-    # Default: preview=False -> rocm6.2
-    assert get_torch_platform(gpu_infos) == "rocm6.2"
-    assert get_torch_platform(gpu_infos, preview=False) == "rocm6.2"
+    # Default: preview=False -> cpu
+    assert get_torch_platform(gpu_infos) == "cpu"
+    assert get_torch_platform(gpu_infos, preview=False) == "cpu"
 
     # preview=True -> rocm6.4
     assert get_torch_platform(gpu_infos, preview=True) == "rocm6.4"
 
 
-def test_eol_cu118_selection(monkeypatch):
-    monkeypatch.setattr("torchruntime.platform_detection.os_name", "Windows")
-    monkeypatch.setattr("torchruntime.platform_detection.arch", "amd64")
-    # Kepler architecture (e.g. GTX 780)
-    gpu_infos = [GPU(NVIDIA, "NVIDIA", "1004", "GK110 [GeForce GTX 780]", True)]
+def test_eol_rocm_5_2_selection(monkeypatch):
+    monkeypatch.setattr("torchruntime.platform_detection.os_name", "Linux")
+    monkeypatch.setattr("torchruntime.platform_detection.arch", "x86_64")
+    gpu_infos = [GPU(AMD, "AMD", 0x1234, "Navi 10", True)]
 
-    # Default: unsupported=True -> cu118
-    assert get_torch_platform(gpu_infos) == "cu118"
-    assert get_torch_platform(gpu_infos, unsupported=True) == "cu118"
+    assert get_torch_platform(gpu_infos) == "rocm5.2"
 
-    # unsupported=False -> raises ValueError
     with pytest.raises(ValueError, match="considered End-of-Life"):
         get_torch_platform(gpu_infos, unsupported=False)
 

--- a/torchruntime/__main__.py
+++ b/torchruntime/__main__.py
@@ -1,6 +1,7 @@
 from .installer import install
 from .utils.torch_test import test
 from .utils import info
+from .utils.args import parse_policy_args
 
 
 def print_usage(entry_command: str):
@@ -18,6 +19,7 @@ Examples:
     {entry_command} install --uv
     {entry_command} install --preview
     {entry_command} install --no-unsupported
+    {entry_command} install --policy stable
     {entry_command} install torch==2.2.0 torchvision==0.17.0
     {entry_command} install --uv torch>=2.0.0 torchaudio
     {entry_command} install torch==2.1.* torchvision>=0.16.0 torchaudio==2.1.0
@@ -39,6 +41,7 @@ Options:
     --uv               Use uv instead of pip for installation
     --preview          Allow preview builds (e.g. ROCm 6.4)
     --no-unsupported   Forbid EOL/unsupported builds (e.g. DirectML / IPEX / Torch 1.x)
+    --policy <name>    Set configuration policy (stable, compat, preview|nightly). Default: compat
 
 Version specification formats (follows pip format):
     package==2.1.0     Exact version
@@ -66,19 +69,26 @@ def main():
 
     if command == "install":
         args = sys.argv[2:] if len(sys.argv) > 2 else []
-        use_uv = "--uv" in args
-        preview = "--preview" in args
-        unsupported = "--no-unsupported" not in args
-        # Remove flags from args to get package list
-        package_versions = [arg for arg in args if arg not in ("--uv", "--preview", "--no-unsupported")] if args else None
+        try:
+            preview, unsupported, cleaned_args = parse_policy_args(args)
+        except ValueError as e:
+            print(f"Error: {e}")
+            return
+
+        use_uv = "--uv" in cleaned_args
+        # Remove --uv from package list
+        package_versions = [arg for arg in cleaned_args if arg != "--uv"]
         install(package_versions, use_uv=use_uv, preview=preview, unsupported=unsupported)
     elif command == "test":
         subcommand = sys.argv[2] if len(sys.argv) > 2 else "all"
         test(subcommand)
     elif command == "info":
         args = sys.argv[2:] if len(sys.argv) > 2 else []
-        preview = "--preview" in args
-        unsupported = "--no-unsupported" not in args
+        try:
+            preview, unsupported, _ = parse_policy_args(args)
+        except ValueError as e:
+            print(f"Error: {e}")
+            return
         from .utils import info
         info(preview=preview, unsupported=unsupported)
     else:

--- a/torchruntime/__main__.py
+++ b/torchruntime/__main__.py
@@ -16,6 +16,8 @@ Commands:
 Examples:
     {entry_command} install
     {entry_command} install --uv
+    {entry_command} install --preview
+    {entry_command} install --no-unsupported
     {entry_command} install torch==2.2.0 torchvision==0.17.0
     {entry_command} install --uv torch>=2.0.0 torchaudio
     {entry_command} install torch==2.1.* torchvision>=0.16.0 torchaudio==2.1.0
@@ -35,6 +37,8 @@ of torch, torchaudio and torchvision will be installed.
 
 Options:
     --uv               Use uv instead of pip for installation
+    --preview          Allow preview builds (e.g. ROCm 6.4)
+    --no-unsupported   Forbid EOL/unsupported builds (e.g. CUDA 11.8)
 
 Version specification formats (follows pip format):
     package==2.1.0     Exact version
@@ -63,14 +67,20 @@ def main():
     if command == "install":
         args = sys.argv[2:] if len(sys.argv) > 2 else []
         use_uv = "--uv" in args
-        # Remove --uv from args to get package list
-        package_versions = [arg for arg in args if arg != "--uv"] if args else None
-        install(package_versions, use_uv=use_uv)
+        preview = "--preview" in args
+        unsupported = "--no-unsupported" not in args
+        # Remove flags from args to get package list
+        package_versions = [arg for arg in args if arg not in ("--uv", "--preview", "--no-unsupported")] if args else None
+        install(package_versions, use_uv=use_uv, preview=preview, unsupported=unsupported)
     elif command == "test":
         subcommand = sys.argv[2] if len(sys.argv) > 2 else "all"
         test(subcommand)
     elif command == "info":
-        info()
+        args = sys.argv[2:] if len(sys.argv) > 2 else []
+        preview = "--preview" in args
+        unsupported = "--no-unsupported" not in args
+        from .utils import info
+        info(preview=preview, unsupported=unsupported)
     else:
         print(f"Unknown command: {command}")
         entry_path = sys.argv[0]

--- a/torchruntime/__main__.py
+++ b/torchruntime/__main__.py
@@ -38,7 +38,7 @@ of torch, torchaudio and torchvision will be installed.
 Options:
     --uv               Use uv instead of pip for installation
     --preview          Allow preview builds (e.g. ROCm 6.4)
-    --no-unsupported   Forbid EOL/unsupported builds (e.g. CUDA 11.8)
+    --no-unsupported   Forbid EOL/unsupported builds (e.g. DirectML / IPEX / Torch 1.x)
 
 Version specification formats (follows pip format):
     package==2.1.0     Exact version

--- a/torchruntime/consts.py
+++ b/torchruntime/consts.py
@@ -3,3 +3,10 @@ CONTACT_LINK = "https://github.com/easydiffusion/torchruntime"
 AMD = "1002"
 NVIDIA = "10de"
 INTEL = "8086"
+
+POLICIES = {
+    "stable": (False, False),  # preview=False, unsupported=False
+    "compat": (False, True),   # preview=False, unsupported=True (Default)
+    "preview": (True, True),   # preview=True, unsupported=True
+    "nightly": (True, True),   # alias for preview
+}

--- a/torchruntime/platform_detection.py
+++ b/torchruntime/platform_detection.py
@@ -103,7 +103,7 @@ def get_torch_platform(gpu_infos, packages=[], preview=False, unsupported=True):
         platform = _get_platform_for_integrated(integrated_devices, preview=preview)
 
     # Segmentation Logic
-    EOL_PLATFORMS = {"cu118", "directml", "ipex", "rocm5.7", "rocm5.5", "rocm5.2", "rocm4.2"}
+    EOL_PLATFORMS = {"directml", "ipex", "rocm5.2", "rocm4.2"}
 
     if not unsupported and platform in EOL_PLATFORMS:
         raise ValueError(
@@ -138,7 +138,13 @@ def _get_platform_for_discrete(gpu_infos, packages=None, preview=False):
                     raise NotImplementedError(
                         f"Torch does not support Navi 4x series of GPUs on Python 3.8. Please switch to a newer Python version to use the latest version of torch!"
                     )
-                return "rocm6.4" if preview else "rocm6.2"
+                if preview:
+                    return "rocm6.4"
+                print(
+                    "[WARNING] Navi 4x series GPUs require preview ROCm builds (rocm6.4). "
+                    "torchruntime will fall back to CPU unless preview=True is enabled."
+                )
+                return "cpu"
             if any(device_name.startswith("Navi") for device_name in device_names) and any(
                 device_name.startswith("Vega 2") for device_name in device_names
             ):  # lowest-common denominator is rocm5.7, which works with both Navi and Vega 20

--- a/torchruntime/utils/__init__.py
+++ b/torchruntime/utils/__init__.py
@@ -7,7 +7,7 @@ from .torch_device_utils import (
 )
 
 
-def info():
+def info(preview=False, unsupported=True):
     from torchruntime.device_db import get_gpus
     from torchruntime.platform_detection import get_torch_platform
     from torchruntime.configuration import configure
@@ -23,7 +23,7 @@ def info():
     print("")
 
     print("--- RECOMMENDED TORCH PLATFORM ---")
-    torch_platform = get_torch_platform(gpu_infos)
+    torch_platform = get_torch_platform(gpu_infos, preview=preview, unsupported=unsupported)
     print(torch_platform)
 
     print("")

--- a/torchruntime/utils/args.py
+++ b/torchruntime/utils/args.py
@@ -1,0 +1,68 @@
+from ..consts import POLICIES
+
+
+def parse_policy_args(args):
+    """
+    Parses arguments for policy and flags.
+    Returns (preview, unsupported, cleaned_args)
+
+    Supports both `--policy NAME` and `--policy=NAME`.
+
+    Logic:
+    1. Determine base configuration from the LAST provided --policy argument (or default 'compat').
+    2. Apply explicit flags (--preview, --no-unsupported) which ALWAYS override the policy.
+    3. Remove policy and flags from args to produce cleaned_args.
+    """
+    # Default: compat
+    preview, unsupported = POLICIES["compat"]
+    
+    # 1. Scan for the last policy to set the baseline
+    last_policy_name = None
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--policy":
+            if i + 1 < len(args):
+                last_policy_name = args[i+1]
+                i += 2
+            else:
+                # We will catch this error in the second pass or we can raise it now.
+                # Raising now is safer.
+                raise ValueError("--policy requires an argument")
+        elif arg.startswith("--policy="):
+            last_policy_name = arg.split("=", 1)[1]
+            if not last_policy_name:
+                raise ValueError("--policy requires an argument")
+            i += 1
+        else:
+            i += 1
+
+    if last_policy_name:
+        if last_policy_name in POLICIES:
+            preview, unsupported = POLICIES[last_policy_name]
+        else:
+            raise ValueError(f"Unknown policy: {last_policy_name}")
+
+    # 2. Apply flags and build cleaned_args
+    cleaned_args = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--policy":
+            # Skip policy and its value (already processed)
+            i += 2
+            continue
+        elif arg.startswith("--policy="):
+            i += 1
+            continue
+        elif arg == "--preview":
+            preview = True
+            i += 1
+        elif arg == "--no-unsupported":
+            unsupported = False
+            i += 1
+        else:
+            cleaned_args.append(arg)
+            i += 1
+            
+    return preview, unsupported, cleaned_args


### PR DESCRIPTION
Refs easydiffusion/torchruntime#25

This adds build-selection knobs (now including `--policy` presets) so app developers can opt into preview wheels and/or fail fast on EOL/unsupported stacks.

Changes:
- Add `get_torch_platform(..., preview=False, unsupported=True)` gating:
  - `preview=False` avoids preview-only recommendations (Navi 4x falls back to CPU; `preview=True` selects `rocm6.4`).
  - `unsupported=False` errors on EOL/unsupported selections (`directml`, `ipex`, `rocm4.2`, `rocm5.2`).
- Plumb options through `install(...)` and CLI:
  - `--policy {compat,stable,preview}` (alias: `nightly`) sets presets for `(preview, unsupported)`.
  - Precedence: defaults -> `--policy` -> explicit flags (`--preview`, `--no-unsupported`).
  - `--preview` enables preview/test/nightly installs; `--no-unsupported` turns EOL/unsupported selections into an error.
- Installer tweaks:
  - XPU uses stable `/whl/xpu` by default; `--preview` switches to `/whl/test/xpu`.
  - `nightly/*` installs require preview.
- Tests: add/adjust unit tests for preview/EOL gating and XPU/nightly behavior.

Test plan:
- `python -m pytest -q`